### PR TITLE
issue 14 - pwd functionality in shell

### DIFF
--- a/src/shell.c
+++ b/src/shell.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <dirent.h>
+#include <unistd.h>
 #include "shell.h"
 
 /**
@@ -27,6 +28,15 @@ void list_directory_contents(void) {
     }
 }
 
+void print_current_directory(void) {
+ char cwd[4096];
+   if (getcwd(cwd, sizeof(cwd)) != 0) {
+       printf("%s\n", cwd);
+   } else {
+       perror("getcwd() error");
+   }
+}
+
 void execute_shell(void) {
     char command[50];
     printf("pcshell> ");
@@ -34,6 +44,8 @@ void execute_shell(void) {
     while (strcmp(command, "exit") != 0) {
         if (strcmp(command, "ls") == 0) {
             list_directory_contents();
+        } else if (strcmp(command, "pwd") == 0) {
+            print_current_directory();
         } else {
             printf("\nhello %s\n", command);
         }

--- a/src/shell.h
+++ b/src/shell.h
@@ -5,5 +5,6 @@
 
 void execute_shell(void);
 void list_directory_contents(void);
+void print_current_directory(void);
 
 #endif


### PR DESCRIPTION
Resolves #14 

What's Changed
- adds pwd support to pcshell - prints current directory 

To test:

run `make clean and make compile`
run `pcshell` in your terminal
type `pwd` to print current directory and verify output